### PR TITLE
docs: add forceError doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Integrate the widget into your frontend framework using the script below. Ensure
       userEmail: "<user email>",
       flowTemplateId: "<flow template id>",
       identityId: "<identity id>",
+      forceError: 'no_error'
     },
     onEvent: (data) => console.log(data),
     isSandbox: true,
@@ -61,6 +62,8 @@ Integrate the widget into your frontend framework using the script below. Ensure
 - **`identityId`**: Necessary only in the `'authenticate'` flow, this identifier must start with `'id_'` and signifies the user's identity.
 - **`onEvent`**: A callback function triggered upon event occurrences, used for capturing and logging event-related data.
 - **`isSandbox`**: (Optional) Indicates if the widget should operate in sandbox mode, defaulting to `false`.
+- **`forceError`**: (Optional) Enum with two values (`no_error` and `validation_error`). Only valid for sandbox environment. Indicates if the flow should simulate a failed validation response.
+ 
 
 #### Events
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
# Version 0.0.54 🎉

### Context

​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.


Documentation for the `forceError` attribute was missing.
### What is being done

​

#### Specifically, it is necessary to review

​

---

#### Additional Info (screenshots, links, sources, etc.)

---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

