### PR TITLE
Feat/add signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,21 @@ Optional props:
 
 The `onEvent` callback is designed to handle various events that occur during widget interaction. Specifically, it receives detailed information upon the successful completion of user flows. Here are the events it handles:
 
-- **`IDENTITY_REGISTERED`**: This event is dispatched when a user successfully completes the registration flow. The event object contains:
+- **`IDENTITY_REGISTERED`**: This event is dispatched when a user successfully completes the validation attempt. The event object contains:
 
   - `eventName`: The name of the event, in this case, `'IDENTITY_REGISTERED'`.
   - `identityId`: The unique identifier for the newly registered identity.
   - `userReference`: The reference identifier for the user, facilitating the association of the event with the user within the company's context.
 
-- **`IDENTITY_AUTHENTICATED`**: This event occurs when a user successfully completes the authentication flow. The event object includes:
+- **`IDENTITY_AUTHENTICATED`**: This event occurs when a user successfully completes an authentication attempt. The event object includes:
 
   - `eventName`: The name of the event, in this case, `'IDENTITY_AUTHENTICATED'`.
+  - `identityId`: The unique identifier for the authenticated identity.
+  - `userReference`: The reference identifier for the user, facilitating the association of the event with the user within the company's context.
+
+- **`IDENTITY_SIGNATURE`**: This event occurs when a user successfully completes a signature attempt. The event object includes:
+
+  - `eventName`: The name of the event, in this case, `'IDENTITY_SIGNATURE'`.
   - `identityId`: The unique identifier for the authenticated identity.
   - `userReference`: The reference identifier for the user, facilitating the association of the event with the user within the company's context.
 

--- a/README.md
+++ b/README.md
@@ -26,20 +26,54 @@ yarn add @soyio/soyio-widget
 
 ## Usage
 
-Integrate the widget into your frontend framework using the script below. Ensure to replace placeholders (e.g., <flow>, <company id>) with actual values relevant to your implementation.
+Integrate the widget into your frontend framework using the script below. Ensure to replace placeholders (e.g., \<flow>, \<company id>) with actual values relevant to your implementation.
+
+### 1. Validation attempt
 
 ```html
 <script>
-  import SoyioWidget from '@soyio/soyio-widget';
+  import { SoyioWidget } from '@soyio/soyio-widget';
 
   // Widget configuration
   const widgetConfig = {
-    flow: "<flow>",
+    flow: "register",
     configProps: {
       companyId: "<company id>",
       userReference: "<user identifier of company>",
       userEmail: "<user email>",
       flowTemplateId: "<flow template id>",
+      forceError: "<error type>",
+      customColor: "<custom color>"
+    },
+    onEvent: (data) => console.log(data),
+    isSandbox: true,
+  };
+
+  // Create widget when needed. In this example, widget is created when page is loaded.
+  document.addEventListener("DOMContentLoaded", function () {
+    new SoyioWidget(widgetConfig);
+  });
+</script>
+```
+
+Optional props:
+* `userReference`
+* `userEmail`
+* `forceError`
+* `customColor`.
+
+### 2. Auth attempt
+
+```html
+<script>
+  import { SoyioWidget } from '@soyio/soyio-widget';
+
+  // Widget configuration
+  const widgetConfig = {
+    flow: "authenticate",
+    configProps: {
+      companyId: "<company id>",
+      userReference: "<user identifier of company>",
       identityId: "<identity id>",
       forceError: "<error type>",
       customColor: "<custom color>"
@@ -55,20 +89,58 @@ Integrate the widget into your frontend framework using the script below. Ensure
 </script>
 ```
 
-#### Attribute Descriptions
+Optional props:
+* `userReference`
+* `forceError`
+* `customColor`.
 
-- **`flow`**: A string that can only take the values `'register'` or `'authenticate'`. Specifies the workflow of the widget.
+### 3. Signature attempt (*coming soon...*)
+
+```html
+<script>
+  import { SoyioWidget } from '@soyio/soyio-widget';
+
+  // Widget configuration
+  const widgetConfig = {
+    flow: "signature",
+    configProps: {
+      companyId: "<company id>",
+      userReference: "<user identifier of company>",
+      signatureTemplateId: "<signature template id>",
+      identityId: "<identity id>",
+      forceError: "<error type>",
+      customColor: "<custom color>"
+    },
+    onEvent: (data) => console.log(data),
+    isSandbox: true,
+  };
+
+  // Create widget when needed. In this example, widget is created when page is loaded.
+  document.addEventListener("DOMContentLoaded", function () {
+    new SoyioWidget(widgetConfig);
+  });
+</script>
+```
+
+Optional props:
+* `userReference`
+* `forceError`
+* `customColor`.
+
+### Attribute Descriptions
+
 - **`companyId`**: The unique identifier for the company, must start with `'com_'`.
-- **`userReference`**: (Optional) A reference identifier provided by the company for the user engaging with the widget. This identifier is used in events (`onEvent` and `webhooks`) to inform the company which user the events are associated with.
-- **`userEmail`**: The user's email address. This field is optional when the flow is `'register'`, where if not provided, Soyio will prompt the user to enter their email. However, for the `'authenticate'` flow, this field should not be provided.
-- **`flowTemplateId`**: Required only in the `'register'` flow, this identifier specifies the order and quantity of documents requested from the user. It must start with `'vt_'`.
-- **`identityId`**: Necessary only in the `'authenticate'` flow, this identifier must start with `'id_'` and signifies the user's identity.
-- **`forceError`**: (Optional) Triggers specific errors for testing or debugging. Used to simulate failure scenarios.
+- **`userReference`**: A reference identifier provided by the company for the user engaging with the widget. This identifier is used in events (`onEvent` and `webhooks`) to inform the company which user the events are associated with.
+- **`userEmail`**: The user's email address. If not provided, Soyio will prompt the user to enter their email.
+- **`flowTemplateId`**: Identifier of template. Specifies the order and quantity of documents requested from the user. It must start with `'vt_'`.
+- **`signatureTemplateId`**: Identifier of template. Specifies the order and quantity of documents to sign. It must start with `'st_'`.
+- **`identityId`**: This identifier must start with `'id_'` and signifies the user's identity.
+- **`isSandbox`**: Indicates if the widget should operate in sandbox mode, defaulting to `false`.
+- **`forceError`**: Triggers specific errors for testing or debugging. Used to simulate failure scenarios. Only works in `sandbox` mode.
 - **`onEvent`**: A callback function triggered upon event occurrences, used for capturing and logging event-related data.
-- **`customColor`**: (Optional) A hex code string that specifies the base color of the interface during either the authentication or registration flow.
-- **`isSandbox`**: (Optional) Indicates if the widget should operate in sandbox mode, defaulting to `false`.
+- **`customColor`**: A hex code string that specifies the base color of the interface during either the authentication or registration flow.
 
-#### Events
+### Events
 
 The `onEvent` callback is designed to handle various events that occur during widget interaction. Specifically, it receives detailed information upon the successful completion of user flows. Here are the events it handles:
 
@@ -93,7 +165,7 @@ The `onEvent` callback is designed to handle various events that occur during wi
 - **`WIDGET_OPENED`**: This event occurs when the user closes the `Soyio` pop up. The event object is as follows:
   - `{ eventName: 'WIDGET_CLOSED' }`.
 
-#### Error types
+#### Force error types
 
 The `forceError` parameter can simulate the following error conditions:
 
@@ -103,3 +175,13 @@ The `forceError` parameter can simulate the following error conditions:
 - `'unknown_error'`: Generates a generic error, representing an unspecified problem.
 - `'expiration_error'`: Occurs when there is an issue with the identity provider that prevents the validation of one or both documents provided by the user, due to unspecified problems in the validation process.
 - `'camera_permission_error'`: Happens when the user does not grant the necessary permissions to access the camera, preventing the completion of the validation flow.
+
+#### Typescript
+
+The `SoyioTypes` module from the `@soyio/soyio-widget` package provides TypeScript type definitions that you can use to integrate the SoyioWidget more seamlessly into your TypeScript projects.
+
+To use the `SoyioTypes` in your project, import it directly from the `@soyio/soyio-widget` package:
+
+```javascript
+import { SoyioTypes } from '@soyio/soyio-widget'
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,5 +2,10 @@ export const CONTAINER_ID = 'soyio-widget-iframe-container';
 export const IFRAME_ID = 'soyio-widget-iframe';
 export const PRODUCTION_URL = 'https://app.soyio.id/widget';
 export const SANDBOX_URL = 'https://sandbox.soyio.id/widget';
-export const FINISHING_EVENTS = ['IDENTITY_AUTHENTICATED', 'IDENTITY_REGISTERED', 'DENIED_CAMERA_PERMISSION'];
+export const FINISHING_EVENTS = [
+  'IDENTITY_AUTHENTICATED',
+  'IDENTITY_REGISTERED',
+  'DENIED_CAMERA_PERMISSION',
+  'REJECTED_SIGNATURE',
+];
 export const CLOSED_EVENT = 'WIDGET_CLOSED';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const SANDBOX_URL = 'https://sandbox.soyio.id/widget';
 export const FINISHING_EVENTS = [
   'IDENTITY_AUTHENTICATED',
   'IDENTITY_REGISTERED',
+  'IDENTITY_SIGNATURE',
   'DENIED_CAMERA_PERMISSION',
   'REJECTED_SIGNATURE',
 ];

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,12 +1,12 @@
 import postRobot from 'post-robot';
 
-import type { ConfigProps } from './types';
+import type { AttemptConfig } from './types';
 
 function setReady(iframe: HTMLIFrameElement) {
   postRobot.send(iframe.contentWindow, 'ready');
 }
 
-function setConfig(iframe: HTMLIFrameElement, config: Partial<ConfigProps>) {
+function setConfig(iframe: HTMLIFrameElement, config: Partial<AttemptConfig>) {
   postRobot.send(iframe.contentWindow, 'config', config);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,42 +2,17 @@ import * as listeners from './listeners';
 import * as SoyioTypes from './types';
 import { showPopUp } from './widget';
 
-class Widget {
-  private flow: SoyioTypes.Flow;
-  private configProps: SoyioTypes.ConfigProps;
+class SoyioWidget {
   private onEvent: (data: SoyioTypes.EventData) => void;
-  private isSandbox: boolean;
 
-  constructor(options: SoyioTypes.WidgetConfig) {
-    this.flow = options.flow;
-    this.configProps = options.configProps;
+  constructor(options: SoyioTypes.AttemptConfig) {
     this.onEvent = options.onEvent;
-    this.isSandbox = options.isSandbox ?? false;
 
-    this.validateProps();
-
-    showPopUp(
-      this.flow,
-      this.configProps,
-      this.isSandbox,
-      options.developmentUrl,
-    );
+    showPopUp(options);
 
     listeners.setListeners({
       onEvent: this.#triggerEvent.bind(this),
     });
-  }
-
-  validateProps() {
-    if (this.flow === 'authenticate') {
-      this.configProps = this.configProps as SoyioTypes.AuthAttemptProps;
-      if (!this.configProps.identityId) throw new Error('identityId is required');
-      if (!this.configProps.companyId) throw new Error('companyId is required');
-    } else if (this.flow === 'register') {
-      this.configProps = this.configProps as SoyioTypes.ValidationAttemptProps;
-      if (!this.configProps.flowTemplateId) throw new Error('flowTemplateId is required');
-      if (!this.configProps.companyId) throw new Error('companyId is required');
-    }
   }
 
   #triggerEvent(data: SoyioTypes.EventData) {
@@ -45,5 +20,5 @@ class Widget {
   }
 }
 
-export default Widget;
-export { SoyioTypes };
+export default SoyioWidget;
+export { SoyioWidget, SoyioTypes };

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -9,17 +9,22 @@ type Hooks = {
   onEvent: (event: any) => void,
 };
 
+let isListenerSet = false;
+
 function buildEventListener(hooks: Hooks) {
   const { onEvent } = hooks;
 
-  postRobot.on(messageTypes.WIDGET_EVENT, (event: any) => {
-    onEvent(event.data);
-    if (FINISHING_EVENTS.includes(event.data.eventName)) {
-      removePopUp();
-    } else if (event.data.eventName === CLOSED_EVENT) {
-      clearOverlayEffects();
-    }
-  });
+  if (!isListenerSet) {
+    postRobot.on(messageTypes.WIDGET_EVENT, (event: any) => {
+      onEvent(event.data);
+      if (FINISHING_EVENTS.includes(event.data.eventName)) {
+        removePopUp();
+      } else if (event.data.eventName === CLOSED_EVENT) {
+        clearOverlayEffects();
+      }
+    });
+    isListenerSet = true;
+  }
 }
 
 export function setListeners(hooks: Hooks) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,7 +28,7 @@ export type SignatureAttemptProps = {
 }
 
 export type EventData = {
-  eventName: 'IDENTITY_REGISTERED' | 'IDENTITY_AUTHENTICATED' | 'DENIED_CAMERA_PERMISSION' | 'REJECTED_SIGNATURE',
+  eventName: 'IDENTITY_REGISTERED' | 'IDENTITY_AUTHENTICATED' | 'IDENTITY_SIGNATURE' | 'DENIED_CAMERA_PERMISSION' | 'REJECTED_SIGNATURE',
   identityId: string,
   userReference?: string
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,7 +28,7 @@ export type SignatureAttemptProps = {
 }
 
 export type EventData = {
-  eventName: 'IDENTITY_REGISTERED' | 'IDENTITY_AUTHENTICATED' | 'DENIED_CAMERA_PERMISSION',
+  eventName: 'IDENTITY_REGISTERED' | 'IDENTITY_AUTHENTICATED' | 'DENIED_CAMERA_PERMISSION' | 'REJECTED_SIGNATURE',
   identityId: string,
   userReference?: string
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export type ForceErrors = 'facial_validation_error' | 'document_validation_error' | 'unknown_error' | 'expiration_error' | 'camera_permission_error';
-export type Flow = 'authenticate' | 'register'
+export type Flow = 'authenticate' | 'register' | 'signature'
 
 export type AuthAttemptProps = {
   companyId: string
@@ -18,7 +18,14 @@ export type ValidationAttemptProps = {
   customColor?: string
 }
 
-export type ConfigProps = AuthAttemptProps | ValidationAttemptProps
+export type SignatureAttemptProps = {
+  companyId: string
+  identityId: string
+  signatureTemplateId: string
+  userReference?: string
+  forceError?: ForceErrors
+  customColor?: string
+}
 
 export type EventData = {
   eventName: 'IDENTITY_REGISTERED' | 'IDENTITY_AUTHENTICATED' | 'DENIED_CAMERA_PERMISSION',
@@ -26,10 +33,28 @@ export type EventData = {
   userReference?: string
 }
 
-export type WidgetConfig = {
-  flow: Flow,
-  configProps: ConfigProps,
+export type ValidationAttemptConfig = {
+  flow: 'register',
+  configProps: ValidationAttemptProps,
   onEvent: (data: EventData) => void,
   isSandbox?: boolean,
   developmentUrl?: string,
 }
+
+export type AuthAttemptConfig = {
+  flow: 'authenticate',
+  configProps: AuthAttemptProps,
+  onEvent: (data: EventData) => void,
+  isSandbox?: boolean,
+  developmentUrl?: string,
+}
+
+export type SignatureAttemptConfig = {
+  flow: 'signature',
+  configProps: SignatureAttemptProps,
+  onEvent: (data: EventData) => void,
+  isSandbox?: boolean,
+  developmentUrl?: string,
+}
+
+export type AttemptConfig = ValidationAttemptConfig | AuthAttemptConfig | SignatureAttemptConfig;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,17 +1,13 @@
 import { PRODUCTION_URL, SANDBOX_URL } from './constants';
-import type { ConfigProps, Flow } from './types';
+import type { AttemptConfig } from './types';
 
-export function getFullUrl(
-  flow: Flow,
-  configProps: ConfigProps,
-  isSandbox: boolean,
-  developmentUrl: string | undefined,
-): string {
-  const baseUrl = developmentUrl || (isSandbox ? SANDBOX_URL : PRODUCTION_URL);
-  const urlParams = Object.entries(configProps)
+export function getFullUrl(options: AttemptConfig): string {
+  const isSandbox = options.isSandbox ?? false;
+  const baseUrl = options.developmentUrl || (isSandbox ? SANDBOX_URL : PRODUCTION_URL);
+  const urlParams = Object.entries(options.configProps)
     .filter(([, value]) => value)
     .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
     .join('&');
 
-  return `${baseUrl}/${flow}?sdk=web&${urlParams}`;
+  return `${baseUrl}/${options.flow}?sdk=web&${urlParams}`;
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,4 +1,4 @@
-import type { ConfigProps, Flow } from './types';
+import type { AttemptConfig } from './types';
 import { getFullUrl } from './utils';
 
 let popupWindow: Window | null = null;
@@ -6,18 +6,11 @@ let popupWindow: Window | null = null;
 function focusPopup() {
   if (popupWindow && !popupWindow.closed) {
     popupWindow.focus();
-  } else {
-    throw new Error('Popup window does not exist or is closed.');
   }
 }
 
-export function showPopUp(
-  flow: Flow,
-  configProps: ConfigProps,
-  isSandbox: boolean,
-  developmentUrl: string | undefined,
-) {
-  const url = getFullUrl(flow, configProps, isSandbox, developmentUrl);
+export function showPopUp(options: AttemptConfig) {
+  const url = getFullUrl(options);
 
   const w = 510;
   const h = 720;


### PR DESCRIPTION
# Version 1.0.8 🎉

### Context

This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

Commir by commit:

1. A refactor has been made on how props are handled. Now, a single object `AttemptProps` is received, and this same object is used for both `showPopUp` and `getFullUrl`.
2. A refactor of types for TypeScript has been done. Now, it will throw an error to those who try to mount any `attempt` with incorrect parameters. This is also why validateProps was removed in commit 1.
3. A refactor of the readme has been done. Now, the three flows are explained separately, to avoid confusion among parameters.
4. The package version has been updated.
5. The `REJECTED_SIGNATURE` event has been added for the new `sign_attempt` flow.
6. A bug where listeners were being set when they already existed has been fixed.
7. Added success signature events.
​

#### Specifically, it is necessary to review

​

---

#### Additional Info (screenshots, links, sources, etc.)

---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

