### PR TITLE
fix(widget): unblur parent window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -12,11 +12,17 @@ function focusPopup() {
   }
 }
 
+export function clearOverlayEffects() {
+  document.body.style.filter = '';
+  document.body.removeEventListener('click', focusPopup);
+}
+
 function setPopupCheckInterval() {
   popupCheckInterval = setInterval(() => {
     if (!popupWindow || popupWindow.closed) {
       if (popupCheckInterval) clearInterval(popupCheckInterval);
-      document.body.style.filter = 'none';
+
+      clearOverlayEffects();
     }
   }, POPUP_CHECK_INTERVAL_MS);
 }
@@ -45,11 +51,6 @@ export function showPopUp(options: AttemptConfig) {
 
   focusPopup();
   setPopupCheckInterval();
-}
-
-export function clearOverlayEffects() {
-  document.body.style.filter = '';
-  document.body.removeEventListener('click', focusPopup);
 }
 
 export function removePopUp() {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,12 +1,24 @@
 import type { AttemptConfig } from './types';
 import { getFullUrl } from './utils';
 
+const POPUP_CHECK_INTERVAL_MS = 500;
+
 let popupWindow: Window | null = null;
+let popupCheckInterval: NodeJS.Timeout | null = null;
 
 function focusPopup() {
   if (popupWindow && !popupWindow.closed) {
     popupWindow.focus();
   }
+}
+
+function setPopupCheckInterval() {
+  popupCheckInterval = setInterval(() => {
+    if (!popupWindow || popupWindow.closed) {
+      if (popupCheckInterval) clearInterval(popupCheckInterval);
+      document.body.style.filter = 'none';
+    }
+  }, POPUP_CHECK_INTERVAL_MS);
 }
 
 export function showPopUp(options: AttemptConfig) {
@@ -32,6 +44,7 @@ export function showPopUp(options: AttemptConfig) {
   popupWindow = window.open(url, 'Soyio', `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`);
 
   focusPopup();
+  setPopupCheckInterval();
 }
 
 export function clearOverlayEffects() {


### PR DESCRIPTION
# Version 1.0.11 🎉

### Context

​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

The parent window did not become unblurred when the user manually closed the popup window.

### What is being done

A popup interval check was implemented.
#### Specifically, it is necessary to review

​

---
#### Additional Info (screenshots, links, sources, etc.)

https://github.com/Soyio-id/soy-io-widget/assets/65751941/4e19b549-f1ee-420a-bed0-62e0c35d1465



---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

