### PR TITLE
fix(focusPopup): scope effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -6,10 +6,11 @@ const POPUP_CHECK_INTERVAL_MS = 500;
 let popupWindow: Window | null = null;
 let popupCheckInterval: NodeJS.Timeout | null = null;
 
-function focusPopup() {
+function focusPopup(event: MouseEvent | null = null) {
   if (popupWindow && !popupWindow.closed) {
     popupWindow.focus();
   }
+  event?.preventDefault();
 }
 
 export function clearOverlayEffects() {
@@ -42,10 +43,7 @@ export function showPopUp(options: AttemptConfig) {
   const top = ((height / 2) - (h / 2));
 
   document.body.style.filter = 'blur(5px)';
-  document.body.addEventListener('click', (event) => {
-    focusPopup();
-    event.preventDefault();
-  });
+  document.body.addEventListener('click', focusPopup);
 
   popupWindow = window.open(url, 'Soyio', `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`);
 


### PR DESCRIPTION
# Version 2.0.1 🎉

### Context

​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done
The prevent default effect from the focus popus is now scoped
​

#### Specifically, it is necessary to review

​

---

#### Additional Info (screenshots, links, sources, etc.)

---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

