### PR TITLE
Post robot event listener cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.10.1",
+    "@types/post-robot": "^10.0.6",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
     "eslint": "^8.57.0",
@@ -38,8 +39,8 @@
     "vitest": "^0.34.6"
   },
   "dependencies": {
+    "post-robot": "^10.0.46",
     "vite": "^5.0.0",
-    "vite-plugin-dts": "^3.6.4",
-    "post-robot": "^10.0.46"
+    "vite-plugin-dts": "^3.6.4"
   }
 }

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -15,7 +15,7 @@ async function buildEventListener(hooks: Hooks) {
   const postRobot = await import('post-robot');
 
   if (!isListenerSet) {
-    postRobot.on(messageTypes.WIDGET_EVENT, (event: any) => {
+    postRobot.on(messageTypes.WIDGET_EVENT, async (event: any) => {
       onEvent(event.data);
       if (FINISHING_EVENTS.includes(event.data.eventName)) {
         removePopUp();

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -4,27 +4,35 @@ import { CLOSED_EVENT, FINISHING_EVENTS } from './constants';
 import { clearOverlayEffects, removePopUp } from './widget';
 
 type Hooks = {
-  onEvent: (event: any) => void,
+  onEvent: (event: any) => void;
 };
 
-let isListenerSet = false;
+type PostRobotListener = ReturnType<typeof import('post-robot')['on']>;
+
+let activeListener: PostRobotListener | null = null;
+
+function removeListener() {
+  if (!activeListener) return;
+
+  activeListener.cancel();
+  activeListener = null;
+}
 
 async function buildEventListener(hooks: Hooks) {
   const { onEvent } = hooks;
 
   const postRobot = await import('post-robot');
 
-  if (!isListenerSet) {
-    postRobot.on(messageTypes.WIDGET_EVENT, async (event: any) => {
-      onEvent(event.data);
-      if (FINISHING_EVENTS.includes(event.data.eventName)) {
-        removePopUp();
-      } else if (event.data.eventName === CLOSED_EVENT) {
-        clearOverlayEffects();
-      }
-    });
-    isListenerSet = true;
-  }
+  if (activeListener) removeListener();
+
+  activeListener = postRobot.on(messageTypes.WIDGET_EVENT, async (event) => {
+    onEvent(event.data);
+    if (FINISHING_EVENTS.includes(event.data.eventName)) {
+      removePopUp();
+    } else if (event.data.eventName === CLOSED_EVENT) {
+      clearOverlayEffects();
+    }
+  });
 }
 
 export function setListeners(hooks: Hooks) {

--- a/src/types/post-robot.d.ts
+++ b/src/types/post-robot.d.ts
@@ -1,1 +1,0 @@
-declare module 'post-robot';

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,6 +392,11 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/post-robot@^10.0.6":
+  version "10.0.6"
+  resolved "https://registry.yarnpkg.com/@types/post-robot/-/post-robot-10.0.6.tgz#9c8b1db55dd109cc36aa5a0d8edbd46827fd572c"
+  integrity sha512-x+LaZPQ4TYW8aBbKpFZsJn7TGipka7tC2ZokE8gpCAlh4E4XFgxxcvt19LD41BeExmlzAtjHh700r3r8SdfX9A==
+
 "@types/semver@^7.5.0":
   version "7.5.6"
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz"


### PR DESCRIPTION
# Version 2.0.2 🎉

### Context

This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

While developing a React example for the widget, I realized that after unmounting a component, states that were modified within the `onEvent` callback weren't called correctly.

After digging up a bit, I realized that the `setState` callbacks were being called, but to a previous instance of the component. This is due to the fact that the listeners in the widget are only set once the script is loaded, but they don't account that the widget might be opened multiple times without reloading the page (such as in a Single Page Application).

This PR cleans up any listeners that were previously defined in the lifecycle of the widget.

I also added the type definitions of the `post-robot` lib and removed the custom type definitions.

#### Specifically, it is necessary to review

Any side effects related that could be triggered by the `isListenerSet` being removed.

---

#### Additional Info (screenshots, links, sources, etc.)

N/A

---

#### Before you merge...

> [!IMPORTANT]
> - [X] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

