### PR TITLE
feat(ConsentRequestBox): support height change events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/embeds/consentRequest.ts
+++ b/src/embeds/consentRequest.ts
@@ -4,7 +4,7 @@ import {
   getFullUrl,
   getIframeDivContainer,
 } from './iframe';
-import { removeListener, setListener } from './listeners';
+import { removeListeners, setListener } from './listeners';
 import type { ConsentRequestConfig } from './types';
 
 class ConsentRequestBox {
@@ -14,7 +14,16 @@ class ConsentRequestBox {
   constructor(options: ConsentRequestConfig) {
     this.options = options;
 
-    setListener({ onEvent: this.options.onEvent.bind(this) });
+    setListener({
+      onEvent: this.options.onEvent.bind(this),
+      onHeightChange: this.handleHeightChange.bind(this),
+    });
+  }
+
+  private handleHeightChange(height: number): void {
+    if (this.iframe) {
+      this.iframe.style.height = `${height}px`;
+    }
   }
 
   mount(selector: string): ConsentRequestBox {
@@ -30,7 +39,7 @@ class ConsentRequestBox {
   }
 
   unmount(): void {
-    removeListener();
+    removeListeners();
 
     if (this.iframe) {
       this.iframe.remove();

--- a/src/embeds/iframe.ts
+++ b/src/embeds/iframe.ts
@@ -12,27 +12,45 @@ export function cleanupExistingIframe(): void {
 }
 
 export function getIframeDivContainer(selector: string): HTMLDivElement {
-  const iframeContainer = document.querySelector(selector);
+  const iframeDivContainer = document.querySelector(selector);
 
-  if (!iframeContainer) {
+  if (!iframeDivContainer) {
     throw new Error(`Iframe div container with id '${selector}' not found`);
   }
 
-  if (iframeContainer.tagName.toLowerCase() !== 'div') {
+  if (iframeDivContainer.tagName.toLowerCase() !== 'div') {
     throw new Error(`Iframe container with id '${selector}' must be a <div> element`);
   }
 
-  return iframeContainer as HTMLDivElement;
+  const container = iframeDivContainer as HTMLDivElement;
+  container.style.position = 'relative';
+  container.style.cssText += `
+    padding: 0 !important;
+    margin: 0 !important;
+    display: block !important;
+    border: none !important;
+    transition: height 0.35s !important;
+    opacity: 1 !important;
+  `;
+
+  return container;
 }
 
 export function createIframe(url: string): HTMLIFrameElement {
   const iframe = document.createElement('iframe');
   iframe.id = CONSENT_REQUEST_IFRAME_ID;
-  iframe.style.zIndex = String(Number.MAX_SAFE_INTEGER);
-  iframe.style.width = '100%';
-  iframe.style.height = '100%';
-  iframe.style.border = 'none';
   iframe.src = url;
+
+  iframe.style.cssText += `
+    width: 100% !important;
+    border: none !important;
+    height: 110px !important;
+    overflow: hidden !important;
+    opacity: 1;
+    transition: height 0.35s,
+    opacity 0.4s 0.1s;
+  `;
+
   return iframe;
 }
 

--- a/src/embeds/listeners.ts
+++ b/src/embeds/listeners.ts
@@ -1,30 +1,43 @@
-import { ConsentRequestEvent, IFRAME_EVENT } from './types';
+import {
+  ConsentRequestEvent,
+  IFRAME_EVENT,
+  IFRAME_HEIGHT_CHANGE,
+  IframeHeightChangeEvent,
+} from './types';
 
-type Hooks = {
+type Events = {
   onEvent: (event: ConsentRequestEvent) => void;
+  onHeightChange: (height: number) => void;
 };
 
 type PostRobotListener = ReturnType<typeof import('post-robot')['on']>;
 
 let activeListener: PostRobotListener | null = null;
+let heightChangeListener: PostRobotListener | null = null;
 
-function removeListener() {
-  if (!activeListener) return;
-
-  activeListener.cancel();
+function removeListeners() {
+  activeListener?.cancel();
   activeListener = null;
+
+  heightChangeListener?.cancel();
+  heightChangeListener = null;
 }
 
-export async function setListener(hooks: Hooks) {
-  const { onEvent } = hooks;
+export async function setListener(events: Events) {
+  const { onEvent, onHeightChange } = events;
   const postRobot = await import('post-robot');
 
-  if (activeListener) removeListener();
+  removeListeners();
 
   activeListener = postRobot.on(IFRAME_EVENT, async (event) => {
     const eventData = event.data as ConsentRequestEvent;
     onEvent(eventData);
   });
+
+  heightChangeListener = postRobot.on(IFRAME_HEIGHT_CHANGE, async (event) => {
+    const eventData = event.data as IframeHeightChangeEvent;
+    onHeightChange(eventData.height);
+  });
 }
 
-export { removeListener };
+export { removeListeners };

--- a/src/embeds/types.ts
+++ b/src/embeds/types.ts
@@ -1,10 +1,18 @@
 export const IFRAME_EVENT = 'IFRAME_EVENT';
+export const IFRAME_HEIGHT_CHANGE = 'IFRAME_HEIGHT_CHANGE';
 
-export type ConsentRequestEvent = {
+export type ConsentCheckboxChangeEvent = {
   eventName: 'CONSENT_CHECKBOX_CHANGE'
   entityId: `ent_${string}`
   isSelected: boolean
 }
+
+export type IframeHeightChangeEvent = {
+  eventName: 'IFRAME_HEIGHT_CHANGE'
+  height: number
+}
+
+export type ConsentRequestEvent = ConsentCheckboxChangeEvent | IframeHeightChangeEvent;
 
 export type ConsentRequestConfig = {
   consentRequestId: `consreq_${string}`,


### PR DESCRIPTION
# Version 2.3.1 🎉

### Context
​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

​Added support for dynamic height events.
Based on: https://docs.stripe.com/payments/elements/link-authentication-element

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

