### PR TITLE
Refactor/change to consent template

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,18 +287,18 @@ Optional props:
 
 ## Consent Request Box
 
-The **`ConsentRequestBox`** is a component that allows you to embed a consent request directly within your webpage, rather than opening it in a popup window. This is particularly useful when you want to integrate the consent flow seamlessly into your application's interface.
+The **`ConsentBox`** is a component that allows you to embed a consent request directly within your webpage, rather than opening it in a popup window. This is particularly useful when you want to integrate the consent flow seamlessly into your application's interface.
 
 ```html
 <!-- Add a container div where the consent request will be mounted -->
 <div id="consent-request-box"></div>
 
 <script>
-  import { ConsentRequestBox } from "@soyio/soyio-widget";
+  import { ConsentBox } from "@soyio/soyio-widget";
 
   // Configuration for the consent request
-  const consentRequestOptions = {
-    consentRequestId: "<consent request id>",
+  const consentOptions = {
+    consentTemplateId: "<consent template id>",
     onEvent: (data) => console.log(data),
     isSandbox: true, // Optional, defaults to false
   };
@@ -306,7 +306,7 @@ The **`ConsentRequestBox`** is a component that allows you to embed a consent re
   // Wait for DOM to be fully loaded
   document.addEventListener("DOMContentLoaded", () => {
     // Create and mount the consent request box
-    new ConsentRequestBox(consentRequestOptions).mount("#consent-request-box");
+    new ConsentBox(consentOptions).mount("#consent-request-box");
   });
 </script>
 ```
@@ -318,16 +318,16 @@ The `onEvent` follows the following format:
 ```typescript
 {
   eventName: 'CONSENT_CHECKBOX_CHANGE',
-  entityId: `ent_${string}`,
   isSelected: boolean
+  token: string,
 }
 ```
 
 ### Attribute Descriptions
 
-- **`consentRequestId`**: Identifier of consent request obtained when creating the `ConsentRequest`. It must start with `'consentreq_'`.
-- **`entityId`**: Identifier of entity obtained when creating the `ConsentRequest`. It must start with `'ent_'`.
+- **`consentTemplateId`**: Identifier of consent template. It must start with `'constpl_'`.
 - **`isSelected`**: Boolean value indicating whether the consent checkbox is selected or not.
+- **`token`**: Unique identifier for the consent. Contains necessary information for creation of the consent request. [Learn more](https://docs.soyio.id/docs/api/resources/create-consent-request).
 
 ## TypeScript
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const CONSENT_REQUEST_IFRAME_ID = 'soyio-consent-request-iframe';
+export const CONSENT_IFRAME_ID = 'soyio-consent-iframe';
 export const PRODUCTION_URL = 'https://app.soyio.id';
 export const SANDBOX_URL = 'https://sandbox.soyio.id';
 export const FINISHING_EVENTS = [

--- a/src/embeds/consent.ts
+++ b/src/embeds/consent.ts
@@ -5,13 +5,13 @@ import {
   getIframeDivContainer,
 } from './iframe';
 import { removeListeners, setListener } from './listeners';
-import type { ConsentRequestConfig } from './types';
+import type { ConsentConfig } from './types';
 
-class ConsentRequestBox {
-  private options: ConsentRequestConfig;
+class ConsentBox {
+  private options: ConsentConfig;
   private iframe: HTMLIFrameElement | null = null;
 
-  constructor(options: ConsentRequestConfig) {
+  constructor(options: ConsentConfig) {
     this.options = options;
 
     setListener({
@@ -26,7 +26,7 @@ class ConsentRequestBox {
     }
   }
 
-  mount(selector: string): ConsentRequestBox {
+  mount(selector: string): ConsentBox {
     cleanupExistingIframe();
 
     const iframeDivContainer = getIframeDivContainer(selector);
@@ -48,4 +48,4 @@ class ConsentRequestBox {
   }
 }
 
-export { ConsentRequestBox };
+export { ConsentBox };

--- a/src/embeds/iframe.ts
+++ b/src/embeds/iframe.ts
@@ -1,12 +1,12 @@
-import { CONSENT_REQUEST_IFRAME_ID, PRODUCTION_URL, SANDBOX_URL } from '../constants';
+import { CONSENT_IFRAME_ID, PRODUCTION_URL, SANDBOX_URL } from '../constants';
 
-import type { ConsentRequestConfig } from './types';
+import type { ConsentConfig } from './types';
 
 export function cleanupExistingIframe(): void {
-  const existingIframe = document.getElementById(CONSENT_REQUEST_IFRAME_ID);
+  const existingIframe = document.getElementById(CONSENT_IFRAME_ID);
   if (existingIframe) {
     // eslint-disable-next-line no-console
-    console.warn('ConsentRequestBox iframe already exists. Removing existing before mounting new one.');
+    console.warn('ConsentBox iframe already exists. Removing existing before mounting new one.');
     existingIframe.remove();
   }
 }
@@ -38,7 +38,7 @@ export function getIframeDivContainer(selector: string): HTMLDivElement {
 
 export function createIframe(url: string): HTMLIFrameElement {
   const iframe = document.createElement('iframe');
-  iframe.id = CONSENT_REQUEST_IFRAME_ID;
+  iframe.id = CONSENT_IFRAME_ID;
   iframe.src = url;
 
   iframe.style.cssText += `
@@ -54,9 +54,9 @@ export function createIframe(url: string): HTMLIFrameElement {
   return iframe;
 }
 
-export function getFullUrl(consentRequestConfig: ConsentRequestConfig): string {
-  const isSandbox = consentRequestConfig.isSandbox ?? false;
-  const baseUrl = consentRequestConfig.developmentUrl || (isSandbox ? SANDBOX_URL : PRODUCTION_URL);
+export function getFullUrl(consentConfig: ConsentConfig): string {
+  const isSandbox = consentConfig.isSandbox ?? false;
+  const baseUrl = consentConfig.developmentUrl || (isSandbox ? SANDBOX_URL : PRODUCTION_URL);
 
-  return `${baseUrl}/embed/consents/${consentRequestConfig.consentRequestId}`;
+  return `${baseUrl}/embed/consents/${consentConfig.consentTemplateId}`;
 }

--- a/src/embeds/index.ts
+++ b/src/embeds/index.ts
@@ -1,3 +1,3 @@
-import { ConsentRequestBox } from './consentRequest';
+import { ConsentBox } from './consent';
 
-export { ConsentRequestBox };
+export { ConsentBox };

--- a/src/embeds/listeners.ts
+++ b/src/embeds/listeners.ts
@@ -1,12 +1,12 @@
 import {
-  ConsentRequestEvent,
+  ConsentEvent,
   IFRAME_EVENT,
   IFRAME_HEIGHT_CHANGE,
   IframeHeightChangeEvent,
 } from './types';
 
 type Events = {
-  onEvent: (event: ConsentRequestEvent) => void;
+  onEvent: (event: ConsentEvent) => void;
   onHeightChange: (height: number) => void;
 };
 
@@ -30,7 +30,7 @@ export async function setListener(events: Events) {
   removeListeners();
 
   activeListener = postRobot.on(IFRAME_EVENT, async (event) => {
-    const eventData = event.data as ConsentRequestEvent;
+    const eventData = event.data as ConsentEvent;
     onEvent(eventData);
   });
 

--- a/src/embeds/types.ts
+++ b/src/embeds/types.ts
@@ -12,11 +12,11 @@ export type IframeHeightChangeEvent = {
   height: number
 }
 
-export type ConsentRequestEvent = ConsentCheckboxChangeEvent | IframeHeightChangeEvent;
+export type ConsentEvent = ConsentCheckboxChangeEvent | IframeHeightChangeEvent;
 
-export type ConsentRequestConfig = {
-  consentRequestId: `consreq_${string}`,
-  onEvent: (data: ConsentRequestEvent) => void,
+export type ConsentConfig = {
+  consentTemplateId: `constpl_${string}`,
+  onEvent: (data: ConsentEvent) => void,
   isSandbox?: boolean,
   developmentUrl?: string,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { ConsentRequestBox } from './embeds';
+import { ConsentBox } from './embeds';
 import * as SoyioTypes from './types';
 import { SoyioWidget } from './widget';
 
 export default SoyioWidget;
-export { ConsentRequestBox, SoyioWidget, SoyioTypes };
+export { ConsentBox, SoyioWidget, SoyioTypes };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type {
-  ConsentRequestEvent,
-  ConsentRequestConfig,
+  ConsentEvent,
+  ConsentConfig,
 } from './embeds/types';
 
 export type {


### PR DESCRIPTION
# Version 2.4.0 🎉

### Context
​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

Refactor of consent module. Now ​refers to consent template instead of of consent request.

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

