### PR TITLE
Feat/consent with action token

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,14 +300,16 @@ The **`ConsentBox`** is a component that allows you to embed a consent request d
   const consentOptions = {
     consentTemplateId: "<consent template id>",
     onEvent: (data) => console.log(data),
-    isSandbox: true, // Optional, defaults to false
+    isSandbox: true, // Optional
     appearance: {}, // Optional
+    actionToken: "<action token>", // Optional
   };
 
   // Wait for DOM to be fully loaded
   document.addEventListener("DOMContentLoaded", () => {
     // Create and mount the consent request box
-    new ConsentBox(consentOptions).mount("#consent-request-box");
+    const consentBox = new ConsentBox(consentOptions);
+    consentBox.mount("#consent-request-box");
   });
 </script>
 ```
@@ -342,6 +344,7 @@ The `onEvent` follows the following format:
 - **`isSelected`**: Boolean value indicating whether the consent checkbox is selected or not.
 - **`actionToken`**: token containing necessary information for creation of the consent commit. [Learn more](https://docs.soyio.id/docs/api/resources/create-consent-request).
 - **`appearance`**: Customize the appearance of the iframe. [Learn more](https://docs.soyio.id/docs/integration-guide/modules/consent).
+- **`actionToken`**: In case of losing the state of the consent (i.e. page reload), you can use a previously generated `actionToken` to restore the state of the consent.
 
 # Appearance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.4.6",
+  "version": "2.5.0",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/embeds/iframe.ts
+++ b/src/embeds/iframe.ts
@@ -62,5 +62,11 @@ export function getFullUrl(consentConfig: ConsentConfig): string {
   const isSandbox = consentConfig.isSandbox ?? false;
   const baseUrl = consentConfig.developmentUrl || (isSandbox ? SANDBOX_URL : PRODUCTION_URL);
 
-  return `${baseUrl}/embed/consents/${consentConfig.consentTemplateId}`;
+  const urlParams = new URLSearchParams();
+  if (consentConfig.actionToken) {
+    urlParams.set('actionToken', consentConfig.actionToken);
+  }
+
+  const queryString = urlParams.toString();
+  return `${baseUrl}/embed/consents/${consentConfig.consentTemplateId}${queryString ? `?${queryString}` : ''}`;
 }

--- a/src/embeds/types.ts
+++ b/src/embeds/types.ts
@@ -40,6 +40,7 @@ export type ConsentConfig = {
   consentTemplateId: `constpl_${string}`,
   onEvent: (data: ConsentEvent) => void,
   isSandbox?: boolean,
-  developmentUrl?: string,
   appearance?: SoyioAppearance,
+  actionToken?: string,
+  developmentUrl?: string,
 }


### PR DESCRIPTION
# Version 2.5.0 🎉

### Context
​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

​Now an `actionToken` is permitted when mounting a `ConsentBox` to restore a previous state.

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

