### PR TITLE
Fix/multiple consent checkboxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,3 @@
-export const CONSENT_IFRAME_ID = 'soyio-consent-iframe';
 export const PRODUCTION_URL = 'https://app.soyio.id';
 export const SANDBOX_URL = 'https://sandbox.soyio.id';
 export const FINISHING_EVENTS = [

--- a/src/embeds/appearance/send.ts
+++ b/src/embeds/appearance/send.ts
@@ -3,6 +3,7 @@ import { SoyioAppearance } from './types';
 export async function sendAppearanceConfig(
   iframe: HTMLIFrameElement,
   appearance: SoyioAppearance,
+  identifier: string,
 ): Promise<void> {
   if (!iframe.contentWindow) {
     throw new Error('Invalid iframe: contentWindow is null');
@@ -11,7 +12,7 @@ export async function sendAppearanceConfig(
   const postRobot = await import('post-robot');
 
   try {
-    await postRobot.send(iframe.contentWindow, 'SET_APPEARANCE', { appearance });
+    await postRobot.send(iframe.contentWindow, 'SET_APPEARANCE', { appearance, identifier });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Failed to send appearance config:', error);

--- a/src/embeds/consent.ts
+++ b/src/embeds/consent.ts
@@ -53,12 +53,12 @@ class ConsentBox {
   }
 
   mount(selector: string): ConsentBox {
-    cleanupExistingIframe();
+    cleanupExistingIframe(this.iframeIdentifier);
 
     const iframeDivContainer = getIframeDivContainer(selector);
     const url = getFullUrl(this.options);
 
-    this.iframe = createIframe(url);
+    this.iframe = createIframe(url, this.iframeIdentifier);
     iframeDivContainer.appendChild(this.iframe);
 
     return this;
@@ -75,6 +75,10 @@ class ConsentBox {
 
   getState(): ConsentState {
     return { ...this.state };
+  }
+
+  get iframeIdentifier(): string {
+    return `consent-box-${this.uniqueIdentifier}`;
   }
 }
 

--- a/src/embeds/iframe.ts
+++ b/src/embeds/iframe.ts
@@ -1,9 +1,9 @@
-import { CONSENT_IFRAME_ID, PRODUCTION_URL, SANDBOX_URL } from '../constants';
+import { PRODUCTION_URL, SANDBOX_URL } from '../constants';
 
 import type { ConsentConfig } from './types';
 
-export function cleanupExistingIframe(): void {
-  const existingIframe = document.getElementById(CONSENT_IFRAME_ID);
+export function cleanupExistingIframe(identifier: string): void {
+  const existingIframe = document.getElementById(identifier);
   if (existingIframe) {
     // eslint-disable-next-line no-console
     console.warn('ConsentBox iframe already exists. Removing existing before mounting new one.');
@@ -38,9 +38,9 @@ export function getIframeDivContainer(selector: string): HTMLDivElement {
   return container;
 }
 
-export function createIframe(url: string): HTMLIFrameElement {
+export function createIframe(url: string, identifier: string): HTMLIFrameElement {
   const iframe = document.createElement('iframe');
-  iframe.id = CONSENT_IFRAME_ID;
+  iframe.id = identifier;
   iframe.src = url;
 
   iframe.style.cssText += `

--- a/src/embeds/types.ts
+++ b/src/embeds/types.ts
@@ -11,23 +11,27 @@ export type ConsentState = {
 }
 
 export type ConsentCheckboxChangeEvent = {
-  eventName: 'CONSENT_CHECKBOX_CHANGE'
-  isSelected: boolean
-  actionToken?: string
+  eventName: 'CONSENT_CHECKBOX_CHANGE';
+  isSelected: boolean;
+  actionToken?: string;
+  identifier: string;
 }
 
 export type IframeReadyEvent = {
   eventName: 'IFRAME_READY';
+  identifier: string;
 };
 
 export type IframeHeightChangeEvent = {
   eventName: 'IFRAME_HEIGHT_CHANGE'
   height: number
+  identifier: string;
 }
 
 export type AppearanceConfigEvent = {
   eventName: 'APPEARANCE_CONFIG';
   appearance: SoyioAppearance;
+  identifier: string;
 };
 
 export type ConsentEvent =


### PR DESCRIPTION
# Version 2.5.1 🎉

### Context
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done
We overlooked the multiple iframe setup case. Our SDK was not prepared to render multiple consents due to listeners / iframe setup logics.

This PR makes multiple consent box support, without affecting the initialization of the component.

#### Specifically, it is necessary to review

The logic: now the post robot listeners are global and never unmounted, but only execute a callback that is registered in the `instanceListeners` variable. This variable is the one that is mutated by each `ConsentBox` instance

---

#### Additional Info (screenshots, links, sources, etc.)

This is how it works now on a demo app. Single consent is still supported.

https://github.com/user-attachments/assets/c34ba583-dbf1-46fd-8f0d-82d1bdd60f80



---

#### Before you merge...

> [!IMPORTANT]
> - [X] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

