### PR TITLE
Feat/consent tooltip v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/embeds/tooltip-manager.ts
+++ b/src/embeds/tooltip-manager.ts
@@ -1,0 +1,91 @@
+export class TooltipManager {
+  private tooltipElement: HTMLElement | null = null;
+  private tooltipContent: HTMLElement | null = null;
+  private readonly tooltipClass = 'soyio-tooltip';
+  private hideTimeout: NodeJS.Timeout | null = null;
+
+  constructor() {
+    this.createTooltipElement();
+    this.setupGlobalListeners();
+  }
+
+  private createTooltipElement(): void {
+    const existingTooltip = document.querySelector(`.${this.tooltipClass}`);
+    existingTooltip?.remove();
+
+    this.tooltipElement = document.createElement('div');
+    this.tooltipElement.className = this.tooltipClass;
+
+    this.tooltipElement.style.cssText = `
+      position: fixed;
+      z-index: 99999;
+      background: white;
+      padding: 8px 12px;
+      border-radius: 4px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+      font-size: 14px;
+      max-width: 300px;
+      word-wrap: break-word;
+      pointer-events: none;
+      opacity: 0;
+      transition: opacity 0.2s ease-in-out;
+      transform: translateX(-50%) translateY(-100%);
+      margin-top: -8px;
+    `;
+
+    this.tooltipContent = document.createElement('div');
+    this.tooltipElement.appendChild(this.tooltipContent);
+
+    const arrow = document.createElement('div');
+    arrow.style.cssText = `
+      position: absolute;
+      bottom: -4px;
+      left: 50%;
+      transform: translateX(-50%) rotate(45deg);
+      width: 8px;
+      height: 8px;
+      background: white;
+      box-shadow: 2px 2px 2px rgba(0,0,0,0.1);
+    `;
+    this.tooltipElement.appendChild(arrow);
+
+    document.body.appendChild(this.tooltipElement);
+  }
+
+  private setupGlobalListeners(): void {
+    window.addEventListener('scroll', () => this.hide(), true);
+    window.addEventListener('resize', () => this.hide());
+    window.addEventListener('orientationchange', () => this.hide());
+  }
+
+  show(text: string, x: number, y: number): void {
+    if (!this.tooltipElement || !this.tooltipContent) return;
+
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout);
+      this.hideTimeout = null;
+    }
+
+    this.tooltipContent.textContent = text;
+    this.tooltipElement.style.left = `${x}px`;
+    this.tooltipElement.style.top = `${y}px`;
+    this.tooltipElement.style.opacity = '1';
+  }
+
+  hide(): void {
+    if (!this.tooltipElement) return;
+
+    this.tooltipElement.style.opacity = '0';
+  }
+
+  destroy(): void {
+    this.tooltipElement?.remove();
+    this.tooltipElement = null;
+    this.tooltipContent = null;
+
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout);
+      this.hideTimeout = null;
+    }
+  }
+}

--- a/src/embeds/types.ts
+++ b/src/embeds/types.ts
@@ -4,6 +4,7 @@ export const IFRAME_READY = 'IFRAME_READY';
 export const CONSENT_STATE_CHANGE = 'CONSENT_STATE_CHANGE';
 export const IFRAME_HEIGHT_CHANGE = 'IFRAME_HEIGHT_CHANGE';
 export const APPEARANCE_CONFIG = 'APPEARANCE_CONFIG';
+export const TOOLTIP_STATE_CHANGE = 'TOOLTIP_STATE_CHANGE';
 
 export type ConsentState = {
   isSelected: boolean;
@@ -34,11 +35,23 @@ export type AppearanceConfigEvent = {
   identifier: string;
 };
 
+export type TooltipStateChangeEvent = {
+  eventName: 'TOOLTIP_STATE_CHANGE';
+  identifier: string;
+  text: string;
+  coordinates: {
+    x: number;
+    y: number;
+  };
+  isVisible: boolean;
+};
+
 export type ConsentEvent =
   | ConsentCheckboxChangeEvent
   | IframeHeightChangeEvent
   | IframeReadyEvent
-  | AppearanceConfigEvent;
+  | AppearanceConfigEvent
+  | TooltipStateChangeEvent;
 
 export type ConsentConfig = {
   consentTemplateId: `constpl_${string}`,


### PR DESCRIPTION
# Version 2.6.0 🎉

### Context

This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

Enhanced the consent module with a new tooltip system that improves the user experience in embedded iframes. The tooltips now render in the parent application, solving visibility issues when the iframe has limited space.

#### Key changes:
- Added new tooltip event system using postRobot for cross-frame communication
- Implemented a lightweight tooltip manager in the SDK that handles positioning and visibility
- Maintains styling consistency across different parent applications
- Zero additional dependencies required in the parent application

#### Specifically, it is necessary to review
- The tooltip manager implementation in `src/tooltip-manager.ts`
- Cross-frame positioning calculations in `ConsentBox` class

---

#### Additional Info (screenshots, links, sources, etc.)

Below is an example of how the tooltip appears in the parent application, positioned correctly relative to the iframe content:

![CleanShot 2025-02-14 at 14 07 54@2x](https://github.com/user-attachments/assets/c5a92ba1-e75d-4800-9e77-a9621f2479a7)

---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget). This step is crucial as it allows for an automatic release process.