### PR TITLE
Feat/consent on ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ The **`ConsentBox`** is a component that allows you to embed a consent request d
     actionToken: "<action token>", // Optional
     entityId: "<entity id>", // Optional
     context: "<context>", // Optional
+    onReady: () => console.log("ConsentBox is ready"), // Optional
   };
 
   // Wait for DOM to be fully loaded
@@ -349,6 +350,7 @@ The `onEvent` follows the following format:
 - **`actionToken`**: In case of losing the state of the consent (i.e. page reload), you can use a previously generated `actionToken` to restore the state of the consent.
 - **`entityId`**: Identifier of the `entity` associated with a `ConsentAction`. If provided and a consent was previously granted by this entity, the UI will display a message indicating that consent has already been given.
 - **`context`**: Additional information that will be saved with the consent. Useful when you want to track the consent from a specific context.
+- **`onReady`**: Optional callback that executes when the consent box is ready to use. You can use this to handle logic when the iframe is not mounted yet.
 
 # Appearance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/embeds/consent.ts
+++ b/src/embeds/consent.ts
@@ -42,6 +42,10 @@ class ConsentBox {
   private async handleIframeReady(): Promise<void> {
     if (!this.iframe || !this.appearance) return;
 
+    if (this.options.onReady) {
+      this.options.onReady();
+    }
+
     await sendAppearanceConfig(this.iframe, this.appearance, this.uniqueIdentifier);
   }
 

--- a/src/embeds/types.ts
+++ b/src/embeds/types.ts
@@ -56,6 +56,7 @@ export type ConsentEvent =
 export type ConsentConfig = {
   consentTemplateId: `constpl_${string}`,
   onEvent: (data: ConsentEvent) => void,
+  onReady?: () => void,
   isSandbox?: boolean,
   appearance?: SoyioAppearance,
   actionToken?: string,


### PR DESCRIPTION
# Version 2.7.3 🎉

### Context

​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

​An optional `onReady` callback can be declared to add control when the `ConsentCheckbox` is not yet ready.

Additionally, a fix was made that prevented the typescript build from completing successfully.

#### Specifically, it is necessary to review

​

---

#### Additional Info (screenshots, links, sources, etc.)

---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

