### PR TITLE
Chore/third party compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,17 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'soyio-widget',
       fileName: 'index',
+      formats: ['es', 'umd'],
     },
     outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+      },
+    },
+    cssCodeSplit: false,
+    target: 'es2015',
   },
   plugins: [dts({ rollupTypes: true })],
 });


### PR DESCRIPTION
# Version 2.8.2 🎉

### Context

This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

One of our potential clients has problems integrating us within a third party platform. The problem lies beneath multiple file bundling. We just confirmed that the extra file is post-robot, as we don't force to bundle everything in one file.

This PR forces our code to bundle into a single file, so that subsequent bundles of our SDK aren't tied to the logics of our internal libraries. This should fix most of third party compat issues related to relative paths

---

#### Before you merge...

> [!IMPORTANT]
> - [X] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

