### PR TITLE
Feat/add base info events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/embeds/base/base-iframe.ts
+++ b/src/embeds/base/base-iframe.ts
@@ -96,6 +96,7 @@ export abstract class BaseIframeBox<T extends BaseConfig> {
       onHeightChange: this.handleHeightChange.bind(this),
       onIframeReady: this.handleIframeReady.bind(this),
       onTooltipChange: this.handleTooltipChange.bind(this),
+      onInfo: this.options.onEvent.bind(this),
     };
 
     mountInstanceListeners(this.uniqueIdentifier, listeners);

--- a/src/embeds/base/types.ts
+++ b/src/embeds/base/types.ts
@@ -5,6 +5,7 @@ export const CONSENT_STATE_CHANGE = 'CONSENT_STATE_CHANGE';
 export const IFRAME_HEIGHT_CHANGE = 'IFRAME_HEIGHT_CHANGE';
 export const APPEARANCE_CONFIG = 'APPEARANCE_CONFIG';
 export const TOOLTIP_STATE_CHANGE = 'TOOLTIP_STATE_CHANGE';
+export const INFO_EVENT = 'INFO_EVENT';
 
 export interface ISkeletonView {
   mount(container: HTMLElement): void;
@@ -45,11 +46,8 @@ export type ConsentEvent =
   | IAppearanceConfigEvent
   | ITooltipStateChangeEvent;
 
-export interface BaseIframeConfig {
-  onReady?: () => void;
-}
-
 export type BaseConfig = {
+  onEvent: (event: Record<string, unknown>) => void,
   onReady?: () => void,
   isSandbox?: boolean,
   appearance?: SoyioAppearance,

--- a/src/embeds/consent/types.ts
+++ b/src/embeds/consent/types.ts
@@ -18,7 +18,6 @@ export type ConsentEvent = ConsentCheckboxChangeEvent;
 
 export type ConsentConfig = BaseConfig & {
   consentTemplateId: `constpl_${string}`,
-  onEvent: (data: ConsentEvent) => void,
   actionToken?: string,
   entityId?: `ent_${string}`,
   context?: string,

--- a/src/embeds/privacy-center/types.ts
+++ b/src/embeds/privacy-center/types.ts
@@ -1,13 +1,6 @@
 import { BaseConfig } from '../base/types';
 
-type WithSubjectId = {
-  subjectId: `ent_${string}`;
-  companyId?: `com_${string}`;
-};
-
-type WithCompanyId = {
-  subjectId?: `ent_${string}`;
+export type PrivacyCenterConfig = BaseConfig & {
   companyId: `com_${string}`;
+  subjectId?: `ent_${string}`;
 };
-
-export type PrivacyCenterConfig = BaseConfig & (WithSubjectId | WithCompanyId);


### PR DESCRIPTION
# Version 2.11.0 🎉

### Context

​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

A new listener is added.
This one only handles communicating the event through the `onEvent` prop that is used to mount the SDK.
It has no internal effect.

#### Specifically, it is necessary to review

​

---

#### Additional Info (screenshots, links, sources, etc.)

---

#### Before you merge...

> [!IMPORTANT]
> - [ ] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

