### PR TITLE
feat(PrivacyCenter): support sessionToken param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/embeds/privacy-center/types.ts
+++ b/src/embeds/privacy-center/types.ts
@@ -1,13 +1,17 @@
 import { BaseConfig } from '../base/types';
 
+export type PrivacyManagerFeature = 'DataSubjectRequest' | 'ConsentManagement';
+
 export type PrivacyCenterConfigWithSessionToken = BaseConfig & {
   sessionToken: string;
+  enabledFeatures?: PrivacyManagerFeature[];
   companyId?: never;
   subjectId?: never;
 };
 
 export type PrivacyCenterConfigWithoutSessionToken = BaseConfig & {
   sessionToken?: never;
+  enabledFeatures?: PrivacyManagerFeature[];
   companyId: `com_${string}`;
   subjectId?: `ent_${string}`;
 };

--- a/src/embeds/privacy-center/types.ts
+++ b/src/embeds/privacy-center/types.ts
@@ -1,6 +1,17 @@
 import { BaseConfig } from '../base/types';
 
-export type PrivacyCenterConfig = BaseConfig & {
+export type PrivacyCenterConfigWithSessionToken = BaseConfig & {
+  sessionToken: string;
+  companyId?: never;
+  subjectId?: never;
+};
+
+export type PrivacyCenterConfigWithoutSessionToken = BaseConfig & {
+  sessionToken?: never;
   companyId: `com_${string}`;
   subjectId?: `ent_${string}`;
 };
+
+export type PrivacyCenterConfig =
+  | PrivacyCenterConfigWithSessionToken
+  | PrivacyCenterConfigWithoutSessionToken;

--- a/src/embeds/privacy-center/utils.ts
+++ b/src/embeds/privacy-center/utils.ts
@@ -3,21 +3,23 @@ import { PRIVACY_BASE_URL, PRIVACY_SANDBOX_URL } from '../../constants';
 import type { PrivacyCenterConfig } from './types';
 
 function getIframeUrl(privacyCenterConfig: PrivacyCenterConfig): string {
-  const URL_PARAMS = [
-    'subjectId',
-    'companyId',
-  ] as const;
-
   const isSandbox = privacyCenterConfig.isSandbox ?? false;
   const baseUrl = privacyCenterConfig.developmentUrl || (isSandbox ? PRIVACY_SANDBOX_URL : PRIVACY_BASE_URL);
 
   const urlParams = new URLSearchParams();
-  URL_PARAMS.forEach((param) => {
-    if (privacyCenterConfig[param]) urlParams.set(param, privacyCenterConfig[param]!);
-  });
+
+  if (privacyCenterConfig.sessionToken) {
+    urlParams.set('sessionToken', privacyCenterConfig.sessionToken);
+  } else if (privacyCenterConfig.companyId) {
+    urlParams.set('companyId', privacyCenterConfig.companyId);
+
+    if (privacyCenterConfig.subjectId) {
+      urlParams.set('subjectId', privacyCenterConfig.subjectId);
+    }
+  }
 
   const queryString = urlParams.toString();
-  return `${baseUrl}/${queryString ? `?${queryString}` : ''}`;
+  return `${baseUrl}${queryString ? `?${queryString}` : ''}`;
 }
 
 export { getIframeUrl };

--- a/src/embeds/privacy-center/utils.ts
+++ b/src/embeds/privacy-center/utils.ts
@@ -18,6 +18,10 @@ function getIframeUrl(privacyCenterConfig: PrivacyCenterConfig): string {
     }
   }
 
+  if (privacyCenterConfig.enabledFeatures?.length) {
+    urlParams.set('enabledFeatures', privacyCenterConfig.enabledFeatures.join(','));
+  }
+
   const queryString = urlParams.toString();
   return `${baseUrl}${queryString ? `?${queryString}` : ''}`;
 }


### PR DESCRIPTION
# Version 2.13.0 🎉

### Context
​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

​Added support for new `sessionToken` param in the `privacyCenter`.

#### Specifically, it is necessary to review

​

---

#### Additional Info (screenshots, links, sources, etc.)

---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

