### PR TITLE
Fix/max width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,15 +25,12 @@ export const CONSENT_DEFAULT_HEIGHT_PX = 120;
 
 export const DEFAULT_IFRAME_CSS_CONFIG: IframeCSSConfig = {
   minWidth: '375px',
-  maxWidth: '50rem',
 };
 
 export const CONSENT_DEFAULT_IFRAME_CSS_CONFIG: IframeCSSConfig = {
   minWidth: '375px',
-  maxWidth: '36rem',
 };
 
 export const PRIVACY_CENTER_DEFAULT_IFRAME_CSS_CONFIG: IframeCSSConfig = {
   minWidth: '375px',
-  maxWidth: '50rem',
 };

--- a/src/embeds/base/utils.ts
+++ b/src/embeds/base/utils.ts
@@ -36,7 +36,6 @@ export function getIframeDivContainer(selector: string): HTMLDivElement {
 
 export type IframeCSSConfig = {
   minWidth?: string;
-  maxWidth?: string;
 }
 
 export function createIframe(url: string, identifier: string, cssConfig: IframeCSSConfig): HTMLIFrameElement {
@@ -47,7 +46,6 @@ export function createIframe(url: string, identifier: string, cssConfig: IframeC
   iframe.style.cssText += `
     width: 100% !important;
     min-width: ${cssConfig.minWidth} !important;
-    max-width: ${cssConfig.maxWidth} !important;
     border: none !important;
     overflow: hidden !important;
     opacity: 1;

--- a/src/embeds/consent/skeleton.ts
+++ b/src/embeds/consent/skeleton.ts
@@ -16,7 +16,6 @@ export class ConsentSkeleton implements ISkeletonView {
       transform: translate(-50%, -50%);
       width: 100%;
       min-width: 375px;
-      max-width: 36rem;
       height: 120px;
       background: #FFFFFF;
       border: 1px solid #E5E7EB;


### PR DESCRIPTION
# Version 2.13.1 🎉

### Context

This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

One of our clients reported some width issues with the Consent box. Our implementation has a hardcoded `max-width` to prevent misuse, but when discussed with the team we reached the conclusion that it is not needed for now at least.

---

#### Additional Info (screenshots, links, sources, etc.)


https://github.com/user-attachments/assets/582696ce-03a7-4f57-bcb8-16eef533971d


---

#### Before you merge...

> [!IMPORTANT]
> - [X] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

