### PR TITLE
chore(package): bump version to 2.13.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
# Version 2.13.5 🎉

### Context

This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

​Bump version to fix previous npm release


#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

