### PR TITLE
Feat/data subjects in privacy center

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,70 @@ The `onEvent` follows the following format:
 
   We don't support hiding the mandatory consent, and we strongly recommend using `notice` so the user doesn't have to give the consent again and knows what they have already given consent to.
 
+## Privacy Center
+
+The `PrivacyCenterBox` lets you embed the Privacy Center inside your page. You can scope which features to show and which data subjects are relevant to your interface. For more info check [our docs](https://docs.soyio.id/).
+
+```html
+<!-- Add a container div where the Privacy Center will be mounted -->
+<div id="privacy-center-box"></div>
+
+<script>
+  import { PrivacyCenterBox } from "@soyio/soyio-widget";
+
+  // Configuration for the Privacy Center
+  const privacyCenterOptions = {
+    // Choose ONE of the following authentication modes:
+    // 1) Session token mode
+    // sessionToken: "<session token>",
+
+    // 2) Company/subject mode
+    companyId: "<company id>", // e.g. com_...
+    subjectId: "<subject id>", // Optional, e.g. ent_...
+
+    // Feature flags (optional)
+    enabledFeatures: ["DataSubjectRequest", "ConsentManagement"],
+
+    // Limit consent view to specific data subjects (optional)
+    dataSubjects: ["customer", "employee"],
+
+    // Common options
+    onEvent: (event) => console.log(event),
+    onReady: () => console.log("PrivacyCenterBox is ready"),
+    isSandbox: true, // Optional
+    appearance: {}, // Optional
+  };
+
+  // Wait for DOM to be fully loaded
+  document.addEventListener("DOMContentLoaded", () => {
+    const privacyCenter = new PrivacyCenterBox(privacyCenterOptions);
+    privacyCenter.mount("#privacy-center-box");
+  });
+</script>
+```
+
+### Attribute Descriptions
+
+- `sessionToken`: Use this to authenticate a session directly.
+- `companyId`: The company identifier. Must start with `com_`. Use this when Privacy Center is mounted in a non authenticated environment.
+- `subjectId`: Optional subject identifier. Must start with `ent_`.
+- `enabledFeatures`: Optional array of features to show. Supported values: `"DataSubjectRequest"`, `"ConsentManagement"`.
+- `dataSubjects`: Optional array of data subject categories. When present, the consent management view only shows consent for the specified categories. Supported values include: `"anonymous_user"`, `"citizen_voter"`, `"commuter"`, `"consultant"`, `"customer"`, `"employee"`, `"job_applicant"`, `"next_of_kin"`, `"passenger"`, `"patient"`, `"prospect"`, `"shareholder"`, `"supplier_vendor"`, `"trainee"`, `"visitor"`.
+- `isSandbox`: Whether to use the sandbox environment. Defaults to `false`.
+- `appearance`: Customize the iframe appearance. See Appearance section below.
+- `onEvent`: Callback that receives events from the iframe.
+- `onReady`: Optional callback fired when the iframe becomes ready.
+
+Note:
+- When `sessionToken` is provided, do not pass `companyId` or `subjectId`.
+
+### Privacy Center Events
+
+- **`REQUEST_SUBMITTED`**: This event occurs when a user successfully submits a Data Subject Request. The event object includes:
+  - `eventName`: The name of the event, in this case, `'REQUEST_SUBMITTED'`.
+  - `subjectId`: The identifier for the user.
+  - `kind`: The kind of the Data Subject Request submitted. Supported values are: `access`, `opposition`, `rectification`, `suppression` and `portability`
+
 # Appearance
 
 Customize the look and feel of Soyio UI components by passing an `appearance` object to the configuration. The appearance object supports themes, CSS variables, and CSS rules for granular control over the styling.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soyio/soyio-widget",
-  "version": "2.13.6",
+  "version": "2.14.0",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",

--- a/src/embeds/privacy-center/types.ts
+++ b/src/embeds/privacy-center/types.ts
@@ -1,6 +1,6 @@
 import { BaseConfig } from '../base/types';
 
-export type PrivacyManagerFeature = 'DataSubjectRequest' | 'ConsentManagement';
+export type PrivacyManagerFeature = 'DataSubjectRequest' | 'ConsentManagement' | 'RequestTracking';
 
 export type DataSubject =
 | 'anonymous_user'

--- a/src/embeds/privacy-center/types.ts
+++ b/src/embeds/privacy-center/types.ts
@@ -2,11 +2,29 @@ import { BaseConfig } from '../base/types';
 
 export type PrivacyManagerFeature = 'DataSubjectRequest' | 'ConsentManagement';
 
+export type DataSubject =
+| 'anonymous_user'
+| 'citizen_voter'
+| 'commuter'
+| 'consultant'
+| 'customer'
+| 'employee'
+| 'job_applicant'
+| 'next_of_kin'
+| 'passenger'
+| 'patient'
+| 'prospect'
+| 'shareholder'
+| 'supplier_vendor'
+| 'trainee'
+| 'visitor';
+
 export type PrivacyCenterConfigWithSessionToken = BaseConfig & {
   sessionToken: string;
   enabledFeatures?: PrivacyManagerFeature[];
   companyId?: never;
   subjectId?: never;
+  dataSubjects?: DataSubject[];
 };
 
 export type PrivacyCenterConfigWithoutSessionToken = BaseConfig & {
@@ -14,6 +32,7 @@ export type PrivacyCenterConfigWithoutSessionToken = BaseConfig & {
   enabledFeatures?: PrivacyManagerFeature[];
   companyId: `com_${string}`;
   subjectId?: `ent_${string}`;
+  dataSubjects?: DataSubject[];
 };
 
 export type PrivacyCenterConfig =

--- a/src/embeds/privacy-center/utils.ts
+++ b/src/embeds/privacy-center/utils.ts
@@ -24,6 +24,10 @@ function getIframeUrl(privacyCenterConfig: PrivacyCenterConfig): string {
     urlParams.set('enabledFeatures', privacyCenterConfig.enabledFeatures.join(','));
   }
 
+  if (privacyCenterConfig.dataSubjects?.length) {
+    urlParams.set('dataSubjects', privacyCenterConfig.dataSubjects.join(','));
+  }
+
   const queryString = urlParams.toString();
   return `${baseUrl}${queryString ? `?${queryString}` : ''}`;
 }


### PR DESCRIPTION
# Version 2.14.0 🎉

### Context

​
This is a [Soyio package](https://www.npmjs.com/package/@soyio/soyio-widget?activeTab=readme) for web applications used for registration and authentication of identities.

### What is being done

​Now you can declare `dataSubjects` in privacy center config. With this, all consent templates shown on the `ConsentManagement` feature will be scoped to the `dataSubjects` that were declared. 



#### Specifically, it is necessary to review

​

---

#### Additional Info (screenshots, links, sources, etc.)

---

#### Before you merge...

> [!IMPORTANT]
> - [x] **Version Update**: Confirm that the `package.json` has been updated to reflect a new version that is higher than the current version on the [main branch](https://github.com/Soyio-id/soy-io-widget), which should be the same version that is available on [npm](https://www.npmjs.com/package/@soyio/soyio-widget).This step is crucial as it allows for an automatic release process.

